### PR TITLE
[BASE] #2 module 공통 plugin 관리를 위한 build-logic 추가 및 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,7 @@
 plugins {
     id("peonlee.android.application")
     id("peonlee.android.compose")
+    id("peonlee.android.hilt")
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt.gradle)
@@ -59,8 +60,4 @@ android {
 dependencies {
     implementation(project(":core-ui"))
     implementation(project(":feature-mymodel"))
-
-    // Hilt Dependency Injection
-    implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,11 +19,6 @@ plugins {
     id("peonlee.android.application")
     id("peonlee.android.application.compose")
     id("peonlee.android.hilt")
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.hilt.gradle)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.kotlin.kapt)
 }
 
 android {
@@ -35,9 +30,9 @@ android {
         versionName = "1.0"
 
         // Enable room auto-migrations
-        ksp {
-            arg("room.schemaLocation", "$projectDir/schemas")
-        }
+//        ksp {
+//            arg("room.schemaLocation", "$projectDir/schemas")
+//        }
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
     id("peonlee.android.application")
-    id("peonlee.android.compose")
+    id("peonlee.android.application.compose")
     id("peonlee.android.hilt")
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,7 @@
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
     id("peonlee.android.application")
+    id("peonlee.android.compose")
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt.gradle)
@@ -41,16 +42,11 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
-    }
-
-    buildFeatures {
-        compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
     }
 
     packagingOptions {
@@ -64,25 +60,7 @@ dependencies {
     implementation(project(":core-ui"))
     implementation(project(":feature-mymodel"))
 
-    // Core Android dependencies
-    implementation(libs.androidx.activity.compose)
-
     // Hilt Dependency Injection
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
-
-    // Arch Components
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-
-    // Compose
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-
-    // Tooling
-    debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@
 
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
+    id("peonlee.android.application")
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt.gradle)
@@ -25,18 +26,11 @@ plugins {
 
 android {
     namespace = "com.peonlee"
-    compileSdk = 33
 
     defaultConfig {
         applicationId = "com.peonlee"
-        minSdk = 21
-        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
-
-        vectorDrawables {
-            useSupportLibrary = true
-        }
 
         // Enable room auto-migrations
         ksp {
@@ -51,21 +45,8 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
     }
 
     composeOptions {
@@ -84,8 +65,6 @@ dependencies {
     implementation(project(":feature-mymodel"))
 
     // Core Android dependencies
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
 
     // Hilt Dependency Injection

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
     id("peonlee.android.application")
     id("peonlee.android.application.compose")
@@ -23,32 +6,13 @@ plugins {
 
 android {
     namespace = "com.peonlee"
-
     defaultConfig {
         applicationId = "com.peonlee"
         versionCode = 1
         versionName = "1.0"
-
-        // Enable room auto-migrations
-//        ksp {
-//            arg("room.schemaLocation", "$projectDir/schemas")
-//        }
     }
-
-    buildTypes {
-        getByName("release") {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-
     packagingOptions {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
+        resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" }
     }
 }
 

--- a/build-logic/.gitignore
+++ b/build-logic/.gitignore
@@ -1,0 +1,3 @@
+build
+.gradle
+./convention/build

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -23,6 +23,10 @@ gradlePlugin {
             id = "peonlee.android.library"
             implementationClass = "AndroidLibraryConventionPlugin"
         }
+        register("androidFeature") {
+            id = "peonlee.android.feature"
+            implementationClass = "AndroidFeatureConventionPlugin"
+        }
         register("androidApplicationCompose") {
             id = "peonlee.android.application.compose"
             implementationClass = "AndroidApplicationComposeConventionPlugin"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `kotlin-dsl`
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+dependencies {
+    compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.ksp.gradlePlugin)
+}

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -19,9 +19,17 @@ gradlePlugin {
             id = "peonlee.android.application"
             implementationClass = "AndroidApplicationConventionPlugin"
         }
+        register("androidLibrary") {
+            id = "peonlee.android.library"
+            implementationClass = "AndroidLibraryConventionPlugin"
+        }
         register("androidApplicationCompose") {
-            id = "peonlee.android.compose"
+            id = "peonlee.android.application.compose"
             implementationClass = "AndroidApplicationComposeConventionPlugin"
+        }
+        register("androidLibraryCompose") {
+            id = "peonlee.android.library.compose"
+            implementationClass = "AndroidLibraryComposeConventionPlugin"
         }
         register("androidHilt") {
             id = "peonlee.android.hilt"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -3,12 +3,21 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
+}
+
+gradlePlugin {
+    plugins {
+        register("androidApplication") {
+            id = "peonlee.android.application"
+            implementationClass = "AndroidApplicationConventionPlugin"
+        }
+    }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -35,5 +35,9 @@ gradlePlugin {
             id = "peonlee.android.hilt"
             implementationClass = "AndroidHiltConventionPlugin"
         }
+        register("androidRoom") {
+            id = "peonlee.android.room"
+            implementationClass = "AndroidRoomConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -23,5 +23,9 @@ gradlePlugin {
             id = "peonlee.android.compose"
             implementationClass = "AndroidApplicationComposeConventionPlugin"
         }
+        register("androidHilt") {
+            id = "peonlee.android.hilt"
+            implementationClass = "AndroidHiltConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -19,5 +19,9 @@ gradlePlugin {
             id = "peonlee.android.application"
             implementationClass = "AndroidApplicationConventionPlugin"
         }
+        register("androidApplicationCompose") {
+            id = "peonlee.android.compose"
+            implementationClass = "AndroidApplicationComposeConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
@@ -1,0 +1,14 @@
+import com.android.build.api.dsl.ApplicationExtension
+import ext.configureAndroidCompose
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val extension = extensions.getByType<ApplicationExtension>()
+            configureAndroidCompose(extension)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.ApplicationExtension
+import const.Version
 import ext.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -14,7 +15,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             }
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)
-                defaultConfig.targetSdk = 33
+                defaultConfig.targetSdk = Version.TARGET_SDK
                 defaultConfig.vectorDrawables {
                     useSupportLibrary = true
                 }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -18,6 +18,16 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 defaultConfig.vectorDrawables {
                     useSupportLibrary = true
                 }
+
+                buildTypes {
+                    getByName("release") {
+                        isMinifyEnabled = false
+                        proguardFiles(
+                            getDefaultProguardFile("proguard-android-optimize.txt"),
+                            "proguard-rules.pro"
+                        )
+                    }
+                }
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -1,0 +1,24 @@
+import com.android.build.api.dsl.ApplicationExtension
+import ext.configureKotlinAndroid
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+@Suppress("UnstableApiUsage")
+class AndroidApplicationConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.android.application")
+                apply("org.jetbrains.kotlin.android")
+            }
+            extensions.configure<ApplicationExtension> {
+                configureKotlinAndroid(this)
+                defaultConfig.targetSdk = 33
+                defaultConfig.vectorDrawables {
+                    useSupportLibrary = true
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -1,0 +1,34 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidFeatureConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("peonlee.android.library")
+                apply("peonlee.android.library.compose")
+                apply("peonlee.android.hilt")
+            }
+
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            dependencies {
+                // Instrumented tests
+                "androidTestImplementation"(
+                    libs.findLibrary("androidx.compose.ui.test.junit4").get()
+                )
+                // Hilt and instrumented tests.
+                "androidTestImplementation"(libs.findLibrary("hilt.android.testing").get())
+                "kaptAndroidTest"(libs.findLibrary("hilt.android.compiler").get())
+                // Hilt and Robolectric tests.
+                "testImplementation"(libs.findLibrary("hilt.android.testing").get())
+                "kaptTest"(libs.findLibrary("hilt.android.compiler").get())
+                // Instrumented tests: jUnit rules and runners
+                "androidTestImplementation"(libs.findLibrary("androidx.test.ext.junit").get())
+                "androidTestImplementation"(libs.findLibrary("androidx.test.runner").get())
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -1,0 +1,21 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidHiltConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            with(pluginManager) {
+                apply("dagger.hilt.android.plugin")
+                apply("org.jetbrains.kotlin.kapt")
+            }
+            dependencies {
+                "implementation"(libs.findLibrary("hilt.android").get())
+                "kapt"(libs.findLibrary("hilt.compiler").get())
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -1,0 +1,14 @@
+import com.android.build.gradle.LibraryExtension
+import ext.configureAndroidCompose
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val extension = extensions.getByType<LibraryExtension>()
+            configureAndroidCompose(extension)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,20 @@
+import com.android.build.gradle.LibraryExtension
+import ext.configureKotlinAndroid
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("com.android.library")
+                apply("org.jetbrains.kotlin.android")
+            }
+            extensions.configure<LibraryExtension> {
+                configureKotlinAndroid(this)
+                defaultConfig.targetSdk = 33
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -2,7 +2,10 @@ import com.android.build.gradle.LibraryExtension
 import ext.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -14,6 +17,13 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
                 defaultConfig.targetSdk = 33
+                defaultConfig.consumerProguardFile("consumer-rules.pro")
+            }
+
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            dependencies {
+                "testImplementation"(libs.findLibrary("junit").get())
+                "testImplementation"(libs.findLibrary("kotlinx.coroutines.test").get())
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.android.build.gradle.LibraryExtension
+import const.Version
 import ext.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -16,7 +17,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             }
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
-                defaultConfig.targetSdk = 33
+                defaultConfig.targetSdk = Version.TARGET_SDK
                 defaultConfig.consumerProguardFile("consumer-rules.pro")
             }
 

--- a/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -1,8 +1,15 @@
+import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.process.CommandLineArgumentProvider
+import java.io.File
 
 class AndroidRoomConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -11,11 +18,23 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.google.devtools.ksp")
             }
+            extensions.configure<KspExtension> {// This is required to enable Room auto migrations..
+                arg(RoomSchemaArgProvider(File(projectDir, "schemas")))
+            }
+
             dependencies {
                 "implementation"(libs.findLibrary("androidx.room.runtime").get())
                 "implementation"(libs.findLibrary("androidx.room.ktx").get())
                 "ksp"(libs.findLibrary("androidx.room.compiler").get())
             }
         }
+    }
+
+    class RoomSchemaArgProvider(
+        @get:InputDirectory
+        @get:PathSensitive(PathSensitivity.RELATIVE)
+        val schemaDir: File,
+    ) : CommandLineArgumentProvider {
+        override fun asArguments() = listOf("room.schemaLocation=${schemaDir.path}")
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -1,0 +1,21 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidRoomConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            with(pluginManager) {
+                apply("com.google.devtools.ksp")
+            }
+            dependencies {
+                "implementation"(libs.findLibrary("androidx.room.runtime").get())
+                "implementation"(libs.findLibrary("androidx.room.ktx").get())
+                "ksp"(libs.findLibrary("androidx.room.compiler").get())
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/const/Version.kt
+++ b/build-logic/convention/src/main/kotlin/const/Version.kt
@@ -1,0 +1,7 @@
+package const
+
+internal object Version {
+    const val TARGET_SDK = 33
+    const val COMPILE_SDK = 33
+    const val MIN_SDK = 26
+}

--- a/build-logic/convention/src/main/kotlin/ext/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/ext/AndroidCompose.kt
@@ -10,7 +10,7 @@ import org.gradle.kotlin.dsl.getByType
  * Compose 와 관련된 Configuration 설정
  */
 @Suppress("UnstableApiUsage")
-internal fun Project.configurationAndroidCompose(
+internal fun Project.configureAndroidCompose(
     commonExtension: CommonExtension<*, *, *, *>
 ) {
     val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/build-logic/convention/src/main/kotlin/ext/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/ext/AndroidCompose.kt
@@ -1,0 +1,31 @@
+package ext
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+/**
+ * Compose 와 관련된 Configuration 설정
+ */
+@Suppress("UnstableApiUsage")
+internal fun Project.configurationAndroidCompose(
+    commonExtension: CommonExtension<*, *, *, *>
+) {
+    val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+    commonExtension.apply {
+        buildFeatures { compose = true }
+        composeOptions {
+            kotlinCompilerExtensionVersion =
+                libs.findVersion("androidxComposeCompiler").get().toString()
+        }
+    }
+    dependencies {
+        val composeBom = platform(libs.findLibrary("androidx.compose.bom").get())
+        "implementation"(composeBom)
+        "implementation"(libs.findBundle("compose").get())
+        "debugImplementation"(libs.findLibrary("androidx.compose.ui.tooling").get())
+        "debugImplementation"(libs.findLibrary("androidx.compose.ui.test.manifest").get())
+    }
+}

--- a/build-logic/convention/src/main/kotlin/ext/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/ext/KotlinAndroid.kt
@@ -1,6 +1,7 @@
 package ext
 
 import com.android.build.api.dsl.CommonExtension
+import const.Version
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -18,10 +19,10 @@ internal fun Project.configureKotlinAndroid(
 ) {
     val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
     commonExtension.apply {
-        compileSdk = 33
+        compileSdk = Version.COMPILE_SDK
 
         defaultConfig {
-            minSdk = 21
+            minSdk = Version.MIN_SDK
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         }
 

--- a/build-logic/convention/src/main/kotlin/ext/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/ext/KotlinAndroid.kt
@@ -1,0 +1,44 @@
+package ext
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+
+/**
+ * kotlin 기반 Android Configuration 설정
+ */
+@Suppress("UnstableApiUsage")
+internal fun Project.configureKotlinAndroid(
+    commonExtension: CommonExtension<*, *, *, *>
+) {
+    commonExtension.apply {
+        compileSdk = 33
+
+        defaultConfig {
+            minSdk = 21
+            testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        }
+
+        buildFeatures {
+            aidl = false
+            buildConfig = false
+            renderScript = false
+            shaders = false
+        }
+
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+        }
+
+        kotlinOptions {
+            jvmTarget = "17"
+        }
+    }
+}
+
+private fun CommonExtension<*, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
+    (this as ExtensionAware).extensions.configure("kotlinOptions", block)
+}

--- a/build-logic/convention/src/main/kotlin/ext/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/ext/KotlinAndroid.kt
@@ -3,7 +3,10 @@ package ext
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 /**
@@ -13,6 +16,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 internal fun Project.configureKotlinAndroid(
     commonExtension: CommonExtension<*, *, *, *>
 ) {
+    val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
     commonExtension.apply {
         compileSdk = 33
 
@@ -36,6 +40,11 @@ internal fun Project.configureKotlinAndroid(
         kotlinOptions {
             jvmTarget = "17"
         }
+    }
+
+    dependencies {
+        "implementation"(libs.findLibrary("androidx.core.ktx").get())
+        "implementation"(libs.findLibrary("androidx.lifecycle.runtime.ktx").get())
     }
 }
 

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true

--- a/build-logic/gradle/wrapper/gradle-wrapper.properties
+++ b/build-logic/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+networkTimeout=10000
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,15 @@
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,3 +15,11 @@
  */
 
 // Root build.gradle.kts
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.hilt.gradle) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+}

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -16,46 +16,20 @@
 
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    id("peonlee.android.library")
+    id("peonlee.android.hilt")
 }
 
 android {
     namespace = "com.peonlee.core.data"
-    compileSdk = 33
 
     defaultConfig {
-        minSdk = 21
-
-        testInstrumentationRunner = "android.template.core.testing.HiltTestRunner"
         consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildFeatures {
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 }
 
 dependencies {
     implementation(project(":core-database"))
-
-    // Arch Components
-    implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
-
     implementation(libs.kotlinx.coroutines.android)
 
     // Local tests: jUnit, coroutines, Android runner

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
     id("peonlee.android.library")
     id("peonlee.android.hilt")
@@ -22,17 +5,9 @@ plugins {
 
 android {
     namespace = "com.peonlee.core.data"
-
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
 }
 
 dependencies {
     implementation(project(":core-database"))
     implementation(libs.kotlinx.coroutines.android)
-
-    // Local tests: jUnit, coroutines, Android runner
-    testImplementation(libs.junit)
-    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core-database/build.gradle.kts
+++ b/core-database/build.gradle.kts
@@ -16,52 +16,22 @@
 
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.kotlin.kapt)
+    id("peonlee.android.library")
+    id("peonlee.android.hilt")
+    id("peonlee.android.room")
 }
 
 android {
     namespace = "com.peonlee.core.database"
-    compileSdk = 33
 
     defaultConfig {
-        minSdk = 21
-
-        testInstrumentationRunner = "android.template.core.testing.HiltTestRunner"
         consumerProguardFiles("consumer-rules.pro")
 
         // The schemas directory contains a schema file for each version of the Room database.
         // This is required to enable Room auto migrations.
         // See https://developer.android.com/reference/kotlin/androidx/room/AutoMigration.
-        ksp {
-            arg("room.schemaLocation", "$projectDir/schemas")
-        }
+//        ksp {
+//            arg("room.schemaLocation", "$projectDir/schemas")
+//        }
     }
-
-    buildFeatures {
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
-
-dependencies {
-    // Arch Components
-    implementation(libs.androidx.room.runtime)
-    implementation(libs.androidx.room.ktx)
-    ksp(libs.androidx.room.compiler)
-    implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
 }

--- a/core-database/build.gradle.kts
+++ b/core-database/build.gradle.kts
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
     id("peonlee.android.library")
     id("peonlee.android.hilt")
@@ -23,15 +6,4 @@ plugins {
 
 android {
     namespace = "com.peonlee.core.database"
-
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-
-        // The schemas directory contains a schema file for each version of the Room database.
-        // This is required to enable Room auto migrations.
-        // See https://developer.android.com/reference/kotlin/androidx/room/AutoMigration.
-//        ksp {
-//            arg("room.schemaLocation", "$projectDir/schemas")
-//        }
-    }
 }

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -1,30 +1,9 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
     id("peonlee.android.library")
 }
 
 android {
     namespace = "com.peonlee.core.testing"
-
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
 }
 
 dependencies {

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -16,40 +16,18 @@
 
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    id("peonlee.android.library")
 }
 
 android {
     namespace = "com.peonlee.core.testing"
-    compileSdk = 33
 
     defaultConfig {
-        minSdk = 21
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildFeatures {
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
     }
 }
 
 dependencies {
-
     implementation(libs.androidx.test.runner)
     implementation(libs.hilt.android.testing)
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -16,54 +16,13 @@
 
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    id("peonlee.android.library")
+    id("peonlee.android.library.compose")
 }
 
 android {
     namespace = "com.peonlee.core.ui"
-    compileSdk = 33
-
     defaultConfig {
-        minSdk = 21
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
-
-    buildFeatures {
-        compose = true
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}
-
-dependencies {
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
-    // Core Android dependencies
-    implementation(libs.androidx.core.ktx)
-
-    // Compose
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-    // Tooling
-    debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
     id("peonlee.android.library")
     id("peonlee.android.library.compose")
@@ -22,7 +5,4 @@ plugins {
 
 android {
     namespace = "com.peonlee.core.ui"
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
 }

--- a/feature-mymodel/build.gradle.kts
+++ b/feature-mymodel/build.gradle.kts
@@ -16,6 +16,8 @@
 
 @Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
+    id("peonlee.android.library")
+    id("peonlee.android.library.compose")
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.kapt)
@@ -23,34 +25,9 @@ plugins {
 
 android {
     namespace = "com.peonlee.feature.mymodel"
-    compileSdk = 33
 
     defaultConfig {
-        minSdk = 21
-
-        testInstrumentationRunner = "com.peonlee.core.testing.HiltTestRunner"
         consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildFeatures {
-        compose = true
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 }
 
@@ -59,20 +36,6 @@ dependencies {
     implementation(project(":core-ui"))
     androidTestImplementation(project(":core-testing"))
 
-    // Core Android dependencies
-    implementation(libs.androidx.activity.compose)
-
-    // Arch Components
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.hilt.navigation.compose)
-
-    // Compose
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-    // Tooling
-    debugImplementation(libs.androidx.compose.ui.tooling)
     // Instrumented tests
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/feature-mymodel/build.gradle.kts
+++ b/feature-mymodel/build.gradle.kts
@@ -18,9 +18,7 @@
 plugins {
     id("peonlee.android.library")
     id("peonlee.android.library.compose")
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    id("peonlee.android.hilt")
 }
 
 android {

--- a/feature-mymodel/build.gradle.kts
+++ b/feature-mymodel/build.gradle.kts
@@ -1,58 +1,13 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-@Suppress("DSL_SCOPE_VIOLATION") // Remove when fixed https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
-    id("peonlee.android.library")
-    id("peonlee.android.library.compose")
-    id("peonlee.android.hilt")
+    id("peonlee.android.feature")
 }
 
 android {
     namespace = "com.peonlee.feature.mymodel"
-
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
 }
 
 dependencies {
     implementation(project(":core-data"))
     implementation(project(":core-ui"))
     androidTestImplementation(project(":core-testing"))
-
-    // Instrumented tests
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
-
-    // Hilt Dependency Injection
-    implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
-    // Hilt and instrumented tests.
-    androidTestImplementation(libs.hilt.android.testing)
-    kaptAndroidTest(libs.hilt.android.compiler)
-    // Hilt and Robolectric tests.
-    testImplementation(libs.hilt.android.testing)
-    kaptTest(libs.hilt.android.compiler)
-
-    // Local tests: jUnit, coroutines, Android runner
-    testImplementation(libs.junit)
-    testImplementation(libs.kotlinx.coroutines.test)
-
-    // Instrumented tests: jUnit rules and runners
-    androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 androidGradlePlugin = "8.0.1"
+androidGradleTool = "7.2.0"
 androidxActivity = "1.7.1"
 androidxComposeBom = "2023.05.00"
 androidxComposeCompiler = "1.4.6"
@@ -18,39 +19,52 @@ kotlin = "1.8.20"
 ksp = "1.8.20-1.0.11"
 
 [libraries]
+# compose
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidxComposeCompiler" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3"}
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui"}
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview"}
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHilt" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+
+# compose test
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4"}
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest"}
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling"}
-androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview"}
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
-androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHilt" }
+
+# android
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
-androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
+
+# room
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidxRoom" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidxRoom" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidxRoom" }
-androidx-test-core  = { module = "androidx.test:core", version.ref = "androidxTestCore" }
-androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExt" }
-androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+
+# hilt
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
+
+# test
 junit = { module = "junit:junit", version.ref = "junit" }
+androidx-test-core  = { module = "androidx.test:core", version.ref = "androidxTestCore" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExt" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+
+# coroutine
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
-# use in build-logic
-android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
-kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-ksp-gradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+# build-logic
+android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradleTool" }
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -60,3 +74,14 @@ hilt-gradle = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
+
+[bundles]
+compose = [
+    "androidx-activity-compose",
+    "androidx-compose-ui",
+    "androidx-compose-material3",
+    "androidx-navigation-compose",
+    "androidx-hilt-navigation-compose",
+    "androidx-compose-ui-tooling-preview",
+    "androidx-lifecycle-viewmodel-compose"
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,11 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
+# use in build-logic
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+ksp-gradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         gradlePluginPortal()
         google()


### PR DESCRIPTION
#### 📌 내용
각 Module의 Build.gradle BoilerPlate를 한 곳에서 관리하기 위한 Plugin 추가를 위한 Build-Logic 생성 및 적용

#### 🛠 Done
- [x] build-logic 생성
- [x] AndroidApplicationConventionPlugin 생성
- [x] AndroidApplicationComposeConventionPlugin 생성
- [x] app module build.gradle에 적용
- [x] AndroidLibraryConvenctionPlugin 생성
- [x] AndroidLibraryComposeConventionPlugin 생성
- [x] AndroidFeatureConventionPlugin 생성
- [x] featrue module / core module에 적용
- [x] AndroidHiltConventionPlugin 생성
- [x] AndroidRoomConventionPlugin 생성

#### 🪴 사용방법
|모듈(사용용도)|plugin|
|-----|----------|
|app|peonlee.android.application|
|feature|peonlee.android.feature|
|core|peonlee.android.library|
|hilt|peonlee.android.hilt|
|roon|peonlee.android.room|
1. [추가사항]
```
- feature는 내부적으로 Hilt가 적용되어 있어 hilt plugin 불필요
- plugin 적용 시 관련 dependency도 추가되므로 별도로 dependency 작성 불필요
```
2. [예시]
```(kotlin)
plugins {
   id("peonlee.android.library")
   id("peonlee.android.hilt")
}
```

#### 🏠 관련 Issue
Closed #2 