### PR TITLE
[BASE] #8 - BaseListAdapter 추가

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -28,6 +28,7 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
                 // Instrumented tests: jUnit rules and runners
                 "androidTestImplementation"(libs.findLibrary("androidx.test.ext.junit").get())
                 "androidTestImplementation"(libs.findLibrary("androidx.test.runner").get())
+                "androidTestImplementation"(libs.findLibrary("androidx.recyclerview").get())
             }
         }
     }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
     implementation(libs.androidx.core.core.ktx)
     implementation(libs.google.material)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.recyclerview)
 }

--- a/core/ui/src/main/java/com/peonlee/core/ui/BaseListAdapter.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/BaseListAdapter.kt
@@ -1,0 +1,38 @@
+package com.peonlee.core.ui
+
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.viewbinding.ViewBinding
+
+abstract class BaseListAdapter<T : Any>(checkParameter: (T) -> Any?) : ListAdapter<T, CommonViewHolder<T>>(BaseDiffUtil<T>(checkParameter)) {
+    final override fun onBindViewHolder(holder: CommonViewHolder<T>, position: Int) {
+        holder.onBindView(currentList[position])
+    }
+
+    final override fun getItemCount(): Int = currentList.size
+
+    private class BaseDiffUtil<T : Any>(private val checkParameter: (T) -> Any?) : DiffUtil.ItemCallback<T>() {
+        override fun areItemsTheSame(oldItem: T, newItem: T): Boolean {
+            return oldItem.isEqualParameter(newItem) {
+                checkParameter(it)
+            }
+        }
+
+        override fun areContentsTheSame(oldItem: T, newItem: T): Boolean {
+            return compareValues(oldItem, newItem)
+        }
+
+        private fun <T : Any> compareValues(a: T, b: T): Boolean {
+            return a == b
+        }
+
+        private fun <T : Any> T.isEqualParameter(other: T, parameter: (T) -> Any?): Boolean {
+            if (this::class != other::class) return false
+            return parameter(this) == parameter(other)
+        }
+    }
+
+    open inner class ViewOnlyViewHolder(binding: ViewBinding) : CommonViewHolder<T>(binding) {
+        final override fun onBindView(item: T) = Unit
+    }
+}

--- a/core/ui/src/main/java/com/peonlee/core/ui/CommonViewHolder.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/CommonViewHolder.kt
@@ -1,0 +1,39 @@
+package com.peonlee.core.ui
+
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
+
+abstract class CommonViewHolder<out E>(binding: ViewBinding) : RecyclerView.ViewHolder(binding.root) {
+    abstract fun onBindView(item: @UnsafeVariance E)
+
+    @PublishedApi
+    internal fun getItemPosition(): Int? {
+        return bindingAdapterPosition.takeIf { it != RecyclerView.NO_POSITION }
+    }
+
+    @PublishedApi
+    internal fun ListAdapter<*, *>.getItem(position: Int): Any? {
+        return try {
+            currentList[position]
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun ListAdapter<*, *>.getItem(action: (item: E) -> Unit) {
+        getItemPosition()?.let { index ->
+            val item = (getItem(index) as? E) ?: return
+            action(item)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun ListAdapter<*, *>.getItemIndexed(action: (index: Int, item: E) -> Unit) {
+        getItemPosition()?.let { index ->
+            val item = (getItem(index) as? E) ?: return
+            action(index, item)
+        }
+    }
+}

--- a/core/ui/src/main/java/com/peonlee/core/ui/MultiTypeListAdapter.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/MultiTypeListAdapter.kt
@@ -1,0 +1,30 @@
+package com.peonlee.core.ui
+
+import android.view.ViewGroup
+import java.lang.reflect.ParameterizedType
+
+interface ListItem {
+    val id: Long
+    val viewType: Enum<*>
+}
+
+abstract class MultiTypeListAdapter<T : ListItem, E : Enum<E>> : BaseListAdapter<T>({ it.id }) {
+    private val enumValues by lazy { getEnumClass().enumConstants ?: throw Exception() }
+
+    final override fun getItemViewType(position: Int): Int {
+        return currentList[position].viewType.ordinal
+    }
+
+    abstract fun onCreateViewHolder(viewType: E, parent: ViewGroup): CommonViewHolder<T>
+
+    final override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommonViewHolder<T> {
+        return onCreateViewHolder(enumValues[viewType], parent)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun getEnumClass(): Class<E> {
+        val genericSuperclass = javaClass.genericSuperclass
+        val type = (genericSuperclass as ParameterizedType).actualTypeArguments[1]
+        return type as Class<E>
+    }
+}

--- a/core/ui/src/main/java/com/peonlee/core/ui/SingleTypeListAdapter.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/SingleTypeListAdapter.kt
@@ -1,0 +1,15 @@
+package com.peonlee.core.ui
+
+import android.view.ViewGroup
+
+abstract class SingleTypeListAdapter<T : Any>(checkParameter: (T) -> Any?) : BaseListAdapter<T>(checkParameter) {
+    final override fun getItemViewType(position: Int): Int {
+        return 0
+    }
+
+    abstract fun onCreateViewHolder(parent: ViewGroup): CommonViewHolder<T>
+
+    final override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommonViewHolder<T> {
+        return onCreateViewHolder(parent)
+    }
+}

--- a/core/ui/src/main/java/com/peonlee/core/ui/extensions/ContextExtensions.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/extensions/ContextExtensions.kt
@@ -2,7 +2,12 @@ package com.peonlee.core.ui.extensions
 
 import android.content.Context
 import android.widget.Toast
+import androidx.annotation.StringRes
 
 fun Context.showToast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}
+
+fun Context.showToast(@StringRes resId: Int) {
+    Toast.makeText(this, getString(resId), Toast.LENGTH_SHORT).show()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidxCore = "1.10.1"
 androidxHilt = "1.0.0"
 androidxLifecycle = "2.6.1"
 androidxNavigation = "2.5.3"
+androidXRecyclerview = "1.3.0"
 androidxRoom = "2.5.1"
 androidxTestCore = "1.5.0"
 androidxTestExt = "1.1.5"
@@ -51,6 +52,9 @@ androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtim
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintLayout" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashScreen" }
 androidx-core-core-ktx = { module = "androidx.core:core-ktx", version = "coreKtx" }
+
+# androidX
+androidx-recyclerview= { module = "androidx.recyclerview:recyclerview", version.ref = "androidXRecyclerview" }
 
 # room
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidxRoom" }


### PR DESCRIPTION
## 개요
interface를 통하여 onBindView 구조를 강제화하고 매번 DiffUtil를 구현해주어야 하는 귀찮음을 줄여준다.
getItem과 getItemIndexed extension을 통해 안전하게 클릭한 객체를 가져올 수 있다.

## 사용방법

```
class ArticleListAdapter : BaseListAdapter<ArticleListItem>({
    when (it) { // DiffUtil areItemsTheSame에서 비교할 파라미터
        is ArticleListItem.Ad.Native -> it.ad.identifier
        is ArticleListItem.Ad.NaverKeyword -> it.ad.clickUrl
        is ArticleListItem.Article -> it.data.id
        is ArticleListItem.LoadMore -> it.lastArticleId
    }
})
```

```
    private inner class ArticleViewHolder(private val binding: ListItemArticleBinding) : CommonViewHolder<ArticleListItem.Article>(binding) {
        init {
            binding.root.setOnClickListener {
                getItemIndexed { index, item -> // getItem extension을 이용해서 Item 가져오기
                    eventListener.onClickArticle(item.data, index)
                }
            }
        }

        override fun onBindView(item: ArticleListItem.Article): Unit = with(binding) {
           .....


   // bind에서 처리할 항목이 없는 단일 view일 경우
   private inner class OneItemViewHolder(binding: ViewBinding) : ViewOnlyViewHolder(binding)
```

