### PR TITLE
[FEATURE] #45 리뷰 작성 화면 API 연동하기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":feature:evaluate"))
     implementation(project(":feature:main"))
     implementation(project(":feature:detail"))
+    implementation(project(":feature:review"))
 
     implementation(libs.androidx.core.splashscreen)
 }

--- a/core/data/src/main/java/com/peonlee/data/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/peonlee/data/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.peonlee.core.data.BuildConfig
 import com.peonlee.data.di.NetworkModule.ConnectInfo.APPLICATION_JSON
 import com.peonlee.data.di.NetworkModule.ConnectInfo.TIME_OUT
 import com.peonlee.data.product.ProductApi
+import com.peonlee.data.review.ReviewApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -61,6 +62,12 @@ object NetworkModule {
     @Provides
     fun provideProductApi(retrofit: Retrofit): ProductApi {
         return retrofit.create(ProductApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideReviewApi(retrofit: Retrofit): ReviewApi {
+        return retrofit.create(ReviewApi::class.java)
     }
 
     private object ConnectInfo {

--- a/core/data/src/main/java/com/peonlee/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/peonlee/data/di/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.peonlee.data.login.LoginRepository
 import com.peonlee.data.login.LoginRepositoryImpl
 import com.peonlee.data.product.DefaultProductRepository
 import com.peonlee.data.product.ProductRepository
+import com.peonlee.data.review.DefaultReviewRepository
+import com.peonlee.data.review.ReviewRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -24,4 +26,10 @@ abstract class RepositoryModule {
     abstract fun bindProductRepository(
         productRepository: DefaultProductRepository
     ): ProductRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindReviewRepository(
+        reviewRepository: DefaultReviewRepository
+    ): ReviewRepository
 }

--- a/core/data/src/main/java/com/peonlee/data/model/review/SaveReviewRequest.kt
+++ b/core/data/src/main/java/com/peonlee/data/model/review/SaveReviewRequest.kt
@@ -1,0 +1,13 @@
+package com.peonlee.data.model.review
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * 리뷰 작성 API Request
+ */
+@Serializable
+data class SaveReviewRequest(
+    @SerialName("content")
+    val review: String
+)

--- a/core/data/src/main/java/com/peonlee/data/model/review/SaveReviewResponse.kt
+++ b/core/data/src/main/java/com/peonlee/data/model/review/SaveReviewResponse.kt
@@ -1,0 +1,14 @@
+package com.peonlee.data.model.review
+
+import kotlinx.serialization.Serializable
+
+/**
+ * 리뷰 작성 API Response
+ */
+@Serializable
+data class SaveReviewResponse(
+    val productCommentId: Int, // 작성한 리뷰 id
+    val productId: Int, // 작성한 상품 id
+    val memberId: Int, // 작성한 사용자 id
+    val content: String // 작성한 리뷰 내용
+)

--- a/core/data/src/main/java/com/peonlee/data/review/DefaultReviewRepository.kt
+++ b/core/data/src/main/java/com/peonlee/data/review/DefaultReviewRepository.kt
@@ -1,5 +1,6 @@
 package com.peonlee.data.review
 
+import com.peonlee.data.model.review.SaveReviewRequest
 import com.peonlee.data.setResult
 import javax.inject.Inject
 
@@ -19,7 +20,7 @@ class DefaultReviewRepository @Inject constructor(
     override suspend fun saveReview(productId: Int, review: String) = setResult {
         reviewApi.saveReview(
             productId = productId,
-            content = review
-        ).body()!!
+            SaveReviewRequest(review = review)
+        ).body() ?: throw IllegalArgumentException()
     }
 }

--- a/core/data/src/main/java/com/peonlee/data/review/DefaultReviewRepository.kt
+++ b/core/data/src/main/java/com/peonlee/data/review/DefaultReviewRepository.kt
@@ -1,0 +1,18 @@
+package com.peonlee.data.review
+
+import javax.inject.Inject
+
+/**
+ * 리뷰 관련 Repository
+ */
+class DefaultReviewRepository @Inject constructor(
+) : ReviewRepository {
+    /**
+     * 새로운 리뷰 저장
+     * @param productId 리뷰를 작성 하는 상품의 id
+     * @param review 사용자가 작성한 리뷰
+     */
+    override suspend fun saveReview(productId: Int, review: String): Result<Unit> {
+        TODO("Not yet implemented")
+    }
+}

--- a/core/data/src/main/java/com/peonlee/data/review/DefaultReviewRepository.kt
+++ b/core/data/src/main/java/com/peonlee/data/review/DefaultReviewRepository.kt
@@ -1,18 +1,25 @@
 package com.peonlee.data.review
 
+import com.peonlee.data.setResult
 import javax.inject.Inject
 
 /**
  * 리뷰 관련 Repository
  */
 class DefaultReviewRepository @Inject constructor(
+    private val reviewApi: ReviewApi
 ) : ReviewRepository {
     /**
      * 새로운 리뷰 저장
+     * TODO runCatching으로 Response 에러 대응 필요
      * @param productId 리뷰를 작성 하는 상품의 id
      * @param review 사용자가 작성한 리뷰
+     * @return 리뷰 저장 API Response
      */
-    override suspend fun saveReview(productId: Int, review: String): Result<Unit> {
-        TODO("Not yet implemented")
+    override suspend fun saveReview(productId: Int, review: String) = setResult {
+        reviewApi.saveReview(
+            productId = productId,
+            content = review
+        ).body()!!
     }
 }

--- a/core/data/src/main/java/com/peonlee/data/review/ReviewApi.kt
+++ b/core/data/src/main/java/com/peonlee/data/review/ReviewApi.kt
@@ -1,0 +1,23 @@
+package com.peonlee.data.review
+
+import com.peonlee.data.model.review.SaveReviewResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * 리뷰와 관련된 API 관리
+ */
+interface ReviewApi {
+    /**
+     * 리뷰 추가 요청
+     * @param productId 리뷰를 작성할 상품의 id
+     * @param content 사용자가 작성한 리뷰 내용
+     */
+    @POST("v1/product/{productId}/comment/write")
+    suspend fun saveReview(
+        @Path("productId") productId: Int,
+        @Body content: String
+    ): Response<SaveReviewResponse>
+}

--- a/core/data/src/main/java/com/peonlee/data/review/ReviewApi.kt
+++ b/core/data/src/main/java/com/peonlee/data/review/ReviewApi.kt
@@ -1,5 +1,6 @@
 package com.peonlee.data.review
 
+import com.peonlee.data.model.review.SaveReviewRequest
 import com.peonlee.data.model.review.SaveReviewResponse
 import retrofit2.Response
 import retrofit2.http.Body
@@ -18,6 +19,6 @@ interface ReviewApi {
     @POST("v1/product/{productId}/comment/write")
     suspend fun saveReview(
         @Path("productId") productId: Int,
-        @Body content: String
+        @Body request: SaveReviewRequest
     ): Response<SaveReviewResponse>
 }

--- a/core/data/src/main/java/com/peonlee/data/review/ReviewRepository.kt
+++ b/core/data/src/main/java/com/peonlee/data/review/ReviewRepository.kt
@@ -1,0 +1,13 @@
+package com.peonlee.data.review
+
+/**
+ * 리뷰와 관련된 Repository
+ */
+interface ReviewRepository {
+    /**
+     * 새로운 리뷰 저장
+     * @param productId 리뷰를 작성 하는 상품의 id
+     * @param review 사용자가 작성한 리뷰
+     */
+    suspend fun saveReview(productId: Int, review: String): Result<Unit>
+}

--- a/core/data/src/main/java/com/peonlee/data/review/ReviewRepository.kt
+++ b/core/data/src/main/java/com/peonlee/data/review/ReviewRepository.kt
@@ -1,5 +1,8 @@
 package com.peonlee.data.review
 
+import com.peonlee.data.Result
+import com.peonlee.data.model.review.SaveReviewResponse
+
 /**
  * 리뷰와 관련된 Repository
  */
@@ -8,6 +11,7 @@ interface ReviewRepository {
      * 새로운 리뷰 저장
      * @param productId 리뷰를 작성 하는 상품의 id
      * @param review 사용자가 작성한 리뷰
+     * @return 리뷰 저장 API Response
      */
-    suspend fun saveReview(productId: Int, review: String): Result<Unit>
+    suspend fun saveReview(productId: Int, review: String): Result<SaveReviewResponse>
 }

--- a/core/ui/src/main/java/com/peonlee/core/ui/extensions/ContextExtensions.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/extensions/ContextExtensions.kt
@@ -4,10 +4,16 @@ import android.content.Context
 import android.widget.Toast
 import androidx.annotation.StringRes
 
+/**
+ * Toast with message String
+ */
 fun Context.showToast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
 }
 
+/**
+ * Toast with message resource id
+ */
 fun Context.showToast(@StringRes resId: Int) {
     Toast.makeText(this, getString(resId), Toast.LENGTH_SHORT).show()
 }

--- a/feature/review/build.gradle.kts
+++ b/feature/review/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     implementation(project(":core:ui"))
+    implementation(project(":core:data"))
     implementation(libs.androidx.constraintlayout)
     implementation(libs.kotlinx.coroutines.android)
 }

--- a/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
+++ b/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
@@ -54,8 +54,11 @@ class EditReviewViewModel @Inject constructor(
                 is Result.Error -> { /* TODO Toast */
                     val exception = saveReviewResult.exception.message
                     _editReviewUiEvent.emit(
-                        if (exception != null) EditReviewUiEvent.Fail.Exception(exception)
-                        else EditReviewUiEvent.Fail.Message(R.string.fail_to_review_api)
+                        if (exception != null) {
+                            EditReviewUiEvent.Fail.Exception(exception)
+                        } else {
+                            EditReviewUiEvent.Fail.Message(R.string.fail_to_review_api)
+                        }
                     )
                 }
 

--- a/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
+++ b/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
@@ -46,8 +46,9 @@ class EditReviewViewModel @Inject constructor(
                 return@launch
             }
             _editReviewUiEvent.emit(EditReviewUiEvent.Loading)
+            // TODO 실제 리뷰를 작성할 상품의 id 로 변경
             val saveReviewResult = reviewRepository.saveReview(
-                productId = 6400,
+                productId = 6399,
                 review = editedReview
             )
             when (saveReviewResult) {

--- a/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
+++ b/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
@@ -1,12 +1,17 @@
 package com.peonlee.review.edit
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.peonlee.data.Result
 import com.peonlee.data.review.ReviewRepository
+import com.peonlee.review.R
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,6 +23,9 @@ class EditReviewViewModel @Inject constructor(
     private val _review = MutableStateFlow("")
     val review: StateFlow<String> = _review.asStateFlow()
 
+    private val _editReviewUiEvent = MutableSharedFlow<EditReviewUiEvent>()
+    val editReviewUiEvent: SharedFlow<EditReviewUiEvent> = _editReviewUiEvent.asSharedFlow()
+
     fun setReview(newReview: String?) {
         if (newReview == null) return
         _review.value = newReview
@@ -27,25 +35,54 @@ class EditReviewViewModel @Inject constructor(
      * 사용자가 작성한 리뷰 저장
      */
     fun saveReview() {
-        // 1. 리뷰 작성 요청
-        val editedReview = _review.value
-        // TODO 글자 수가 부족할 때 UI로 알려 주기
-        if (editedReview.length < 10) return
-
         viewModelScope.launch {
+            // 1. 리뷰 작성 요청
+            val editedReview = _review.value
+            // TODO 글자 수가 부족할 때 UI로 알려 주기
+            if (editedReview.length < 10) {
+                _editReviewUiEvent.emit(
+                    EditReviewUiEvent.Fail.Message(R.string.fail_to_review_length)
+                )
+                return@launch
+            }
+            _editReviewUiEvent.emit(EditReviewUiEvent.Loading)
             val saveReviewResult = reviewRepository.saveReview(
                 productId = 6400,
                 review = editedReview
             )
             when (saveReviewResult) {
                 is Result.Error -> { /* TODO Toast */
-                    println(saveReviewResult.exception)
+                    val exception = saveReviewResult.exception.message
+                    _editReviewUiEvent.emit(
+                        if (exception != null) EditReviewUiEvent.Fail.Exception(exception)
+                        else EditReviewUiEvent.Fail.Message(R.string.fail_to_review_api)
+                    )
                 }
 
                 is Result.Success -> { /* TODO Toast + BackStack */
-                    println("Success")
+                    _editReviewUiEvent.emit(EditReviewUiEvent.Success)
                 }
             }
         }
     }
+}
+
+sealed interface EditReviewUiEvent {
+    object Loading : EditReviewUiEvent
+
+    // 리뷰 작성 실패 Event
+    sealed interface Fail : EditReviewUiEvent {
+        data class Exception(
+            // Exception 을 통해 전달된 메세지
+            val message: String
+        ) : Fail
+
+        data class Message(
+            // Toast로 보여줄 message resource id
+            @StringRes val message: Int
+        ) : Fail
+    }
+
+    // 리뷰 작성 성공 Event
+    object Success : EditReviewUiEvent
 }

--- a/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
+++ b/feature/review/src/main/java/com/peonlee/review/edit/EditReviewViewModel.kt
@@ -1,14 +1,20 @@
 package com.peonlee.review.edit
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.peonlee.data.Result
+import com.peonlee.data.review.ReviewRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class EditReviewViewModel @Inject constructor() : ViewModel() {
+class EditReviewViewModel @Inject constructor(
+    private val reviewRepository: ReviewRepository
+) : ViewModel() {
     private val _review = MutableStateFlow("")
     val review: StateFlow<String> = _review.asStateFlow()
 
@@ -17,7 +23,29 @@ class EditReviewViewModel @Inject constructor() : ViewModel() {
         _review.value = newReview
     }
 
+    /**
+     * 사용자가 작성한 리뷰 저장
+     */
     fun saveReview() {
-        // TODO 리뷰 저장 로직 추가 예정
+        // 1. 리뷰 작성 요청
+        val editedReview = _review.value
+        // TODO 글자 수가 부족할 때 UI로 알려 주기
+        if (editedReview.length < 10) return
+
+        viewModelScope.launch {
+            val saveReviewResult = reviewRepository.saveReview(
+                productId = 6400,
+                review = editedReview
+            )
+            when (saveReviewResult) {
+                is Result.Error -> { /* TODO Toast */
+                    println(saveReviewResult.exception)
+                }
+
+                is Result.Success -> { /* TODO Toast + BackStack */
+                    println("Success")
+                }
+            }
+        }
     }
 }

--- a/feature/review/src/main/res/values/strings.xml
+++ b/feature/review/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="edit_review_text_count">%d/%d</string>
     <string name="edit_review_close_button_description">리뷰 종료</string>
     <string name="edit_review_product_img_description">상품 이미지</string>
+
+    <!-- Toast 메세지 -->
+    <string name="fail_to_review_length">리뷰는 최대 10글자 이상 적어주셔야 합니다.</string>
+    <string name="fail_to_review_api">리뷰를 저장하는 도중 문제가 발생하였습니다.</string>
 </resources>


### PR DESCRIPTION
### 📌 내용
리뷰 작성 화면에서 리뷰 저장 API 연동하기
( * 리뷰 작성 성공 시, 이전 화면으로 이동 )

### 🛠️ Done
 - [x] 리뷰 저장 요청
 - [x] 저장 성공 시 -> Toast + 이전 화면으로 이동
 - [x] 저장 실패 시 -> Toast

### 🪴 To Do
- 실제로 리뷰를 작성할 상품의 id 로 변경 필요

### 🏠 테스트 주의 사항
```
현재는 로그인 기능이 없어, 동일한 상품으로 여러번 테스트할 수 없습니다.
```

### 🍿 관련 Issue
Closed #45 