### PR TITLE
[FEATRUE] #49 검색 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(project(":feature:main"))
     implementation(project(":feature:detail"))
     implementation(project(":feature:review"))
+    implementation(project(":feature:explore"))
 
     implementation(libs.androidx.core.splashscreen)
 }

--- a/feature/explore/build.gradle.kts
+++ b/feature/explore/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 dependencies {
     implementation(libs.google.material)
     implementation(libs.androidx.recyclerview)
+    implementation(libs.androidx.constraintlayout)
 }

--- a/feature/explore/src/main/AndroidManifest.xml
+++ b/feature/explore/src/main/AndroidManifest.xml
@@ -1,2 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name=".ExploreActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
+++ b/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
@@ -12,6 +12,6 @@ class ExploreActivity : BaseActivity<ActivityExploreActivityBinding>() {
         etExplore.addTextChangedListener { input -> ivTextCleaer.isVisible = input?.isNotEmpty() ?: false }
         tvExploreCancel.setOnClickListener { finish() }
         ivTextCleaer.setOnClickListener { etExplore.setText("") }
-        ivSearch.setOnClickListener {  }
+        ivSearch.setOnClickListener { }
     }
 }

--- a/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
+++ b/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
@@ -1,0 +1,12 @@
+package com.peonlee.explore
+
+import com.peonlee.core.ui.base.BaseActivity
+import com.peonlee.explore.databinding.ActivityExploreActivityBinding
+
+class ExploreActivity : BaseActivity<ActivityExploreActivityBinding>() {
+    override fun bindingFactory(): ActivityExploreActivityBinding = ActivityExploreActivityBinding.inflate(layoutInflater)
+
+    override fun initViews() {
+
+    }
+}

--- a/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
+++ b/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
@@ -1,12 +1,17 @@
 package com.peonlee.explore
 
+import androidx.core.view.isVisible
+import androidx.core.widget.addTextChangedListener
 import com.peonlee.core.ui.base.BaseActivity
 import com.peonlee.explore.databinding.ActivityExploreActivityBinding
 
 class ExploreActivity : BaseActivity<ActivityExploreActivityBinding>() {
     override fun bindingFactory(): ActivityExploreActivityBinding = ActivityExploreActivityBinding.inflate(layoutInflater)
 
-    override fun initViews() {
-
+    override fun initViews() = with(binding) {
+        etExplore.addTextChangedListener { input -> ivTextCleaer.isVisible = input?.isNotEmpty() ?: false }
+        tvExploreCancel.setOnClickListener { finish() }
+        ivTextCleaer.setOnClickListener { etExplore.setText("") }
+        ivSearch.setOnClickListener {  }
     }
 }

--- a/feature/explore/src/main/res/layout/activity_explore_activity.xml
+++ b/feature/explore/src/main/res/layout/activity_explore_activity.xml
@@ -60,4 +60,13 @@
         app:layout_constraintBottom_toBottomOf="@+id/et_explore"
         app:layout_constraintEnd_toEndOf="@+id/et_explore"
         app:layout_constraintTop_toTopOf="@+id/et_explore"></ImageView>
+
+    <FrameLayout
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/space_s_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/tv_explore_cancel"
+        app:layout_constraintStart_toStartOf="@+id/et_explore"
+        app:layout_constraintTop_toBottomOf="@+id/et_explore"></FrameLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/explore/src/main/res/layout/activity_explore_activity.xml
+++ b/feature/explore/src/main/res/layout/activity_explore_activity.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ExploreActivity">
+
+    <EditText
+        android:id="@+id/et_explore"
+        style="@style/Text.Subtitle02"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/explore_bar_height"
+        android:layout_marginStart="@dimen/explore_bar_margin"
+        android:layout_marginTop="@dimen/space_large"
+        android:background="@drawable/bg_white_radius_10dp"
+        android:backgroundTint="@color/bg10"
+        android:hint="@string/explore_text_hint"
+        android:paddingLeft="@dimen/explore_text_left_padding"
+        android:textColorHint="@color/bg40"
+        app:layout_constraintEnd_toStartOf="@+id/tv_explore_cancel"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:hint="라면, 음료, 과자, 빵 등"
+        tools:text="우유"></EditText>
+
+    <TextView
+        android:id="@+id/tv_explore_cancel"
+        style="@style/Text.Subtitle02"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/space_x_medium"
+        android:padding="@dimen/space_medium"
+        android:text="@string/explore_cancel"
+        android:textColor="@color/bg40"
+        app:layout_constraintBottom_toBottomOf="@+id/et_explore"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/et_explore"></TextView>
+
+    <ImageView
+        android:id="@+id/iv_search"
+        android:layout_width="@dimen/explore_icon_size"
+        android:layout_height="@dimen/explore_icon_size"
+        android:layout_marginStart="@dimen/space_s_large"
+        android:background="@drawable/ic_search"
+        android:backgroundTint="@color/bg40"
+        app:layout_constraintBottom_toBottomOf="@+id/et_explore"
+        app:layout_constraintStart_toStartOf="@+id/et_explore"
+        app:layout_constraintTop_toTopOf="@+id/et_explore"></ImageView>
+
+    <ImageView
+        android:id="@+id/iv_text_cleaer"
+        android:layout_width="@dimen/explore_icon_size"
+        android:layout_height="@dimen/explore_icon_size"
+        android:layout_marginEnd="12dp"
+        android:padding="@dimen/space_x_small"
+        android:src="@drawable/ic_close_search"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/et_explore"
+        app:layout_constraintEnd_toEndOf="@+id/et_explore"
+        app:layout_constraintTop_toTopOf="@+id/et_explore"></ImageView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/explore/src/main/res/values/dimens.xml
+++ b/feature/explore/src/main/res/values/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="explore_bar_height">48dp</dimen>
+    <dimen name="explore_bar_margin">18dp</dimen>
+    <dimen name="explore_icon_size">24dp</dimen>
+    <dimen name="explore_text_left_padding">48dp</dimen>
+</resources>

--- a/feature/explore/src/main/res/values/strings.xml
+++ b/feature/explore/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="explore_cancel">취소</string>
+    <string name="explore_text_hint">라면, 음료, 과자, 빵 등</string>
+</resources>


### PR DESCRIPTION
## 참고사항 
- 편의점 상품을 검색할 수 있는 화면을 구현합니다.
- 검색 화면을 구현했습니다. 상품 목록은 FrameLayout으로 사용합니다.

![image](https://github.com/YAPP-Github/22nd-Android-Team-1-Android/assets/70135188/a6d4233c-c8ed-43e0-9f52-965bed26c142)

## 내용
1. 검색 화면 구현
2. 검색어 observable 처리


### Done!
 - [x] EditText 구현
 - [x] 검색어 입력 observe 구현

### 관련 Issue
#49  