### PR TITLE
[FEATURE] #60 검색 화면 상품 목록 연동

### DIFF
--- a/core/data/src/main/java/com/peonlee/data/product/ProductApi.kt
+++ b/core/data/src/main/java/com/peonlee/data/product/ProductApi.kt
@@ -1,8 +1,8 @@
 package com.peonlee.data.product
 
 import com.peonlee.data.model.ProductDetail
-import com.peonlee.data.model.response.SearchProductResponse
 import com.peonlee.data.model.Score
+import com.peonlee.data.model.response.SearchProductResponse
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path

--- a/core/data/src/main/java/com/peonlee/data/product/ProductRepository.kt
+++ b/core/data/src/main/java/com/peonlee/data/product/ProductRepository.kt
@@ -4,9 +4,9 @@ import androidx.paging.PagingData
 import com.peonlee.data.Result
 import com.peonlee.data.model.Product
 import com.peonlee.data.model.ProductDetail
-import com.peonlee.data.model.response.SearchProductResponse
 import com.peonlee.data.model.Score
 import com.peonlee.data.model.request.ProductSearchRequest
+import com.peonlee.data.model.response.SearchProductResponse
 import kotlinx.coroutines.flow.Flow
 
 interface ProductRepository {

--- a/core/domain/src/main/java/com/peonlee/domain/login/GetHomeProductUseCase.kt
+++ b/core/domain/src/main/java/com/peonlee/domain/login/GetHomeProductUseCase.kt
@@ -1,8 +1,8 @@
 package com.peonlee.domain.login
 
 import com.peonlee.data.Result
-import com.peonlee.data.model.response.SearchProductResponse
 import com.peonlee.data.model.request.ProductSearchRequest
+import com.peonlee.data.model.response.SearchProductResponse
 import com.peonlee.data.product.ProductRepository
 import com.peonlee.model.type.SortType
 import kotlinx.coroutines.Dispatchers

--- a/core/ui/src/main/java/com/peonlee/core/ui/extensions/EditTextExtension.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/extensions/EditTextExtension.kt
@@ -1,5 +1,6 @@
 package com.peonlee.core.ui.extensions
 
+import android.view.View
 import android.widget.EditText
 import com.peonlee.core.ui.util.keyboard.KeyboardUtil
 
@@ -10,4 +11,12 @@ import com.peonlee.core.ui.util.keyboard.KeyboardUtil
 fun EditText.focus() {
     requestFocus() // focus 요청
     KeyboardUtil.show(findFocus()) // 키보드 생성
+}
+
+fun EditText.hideKeyboard() {
+    KeyboardUtil.hide(this)
+}
+
+fun EditText.trim() : String {
+    return this.text.trim().toString()
 }

--- a/core/ui/src/main/java/com/peonlee/core/ui/extensions/EditTextExtension.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/extensions/EditTextExtension.kt
@@ -1,6 +1,5 @@
 package com.peonlee.core.ui.extensions
 
-import android.view.View
 import android.widget.EditText
 import com.peonlee.core.ui.util.keyboard.KeyboardUtil
 
@@ -17,6 +16,6 @@ fun EditText.hideKeyboard() {
     KeyboardUtil.hide(this)
 }
 
-fun EditText.trim() : String {
+fun EditText.trim(): String {
     return this.text.trim().toString()
 }

--- a/core/ui/src/main/res/layout/list_item_product.xml
+++ b/core/ui/src/main/res/layout/list_item_product.xml
@@ -9,6 +9,7 @@
         android:id="@+id/layoutImage"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:theme="@style/Theme.MaterialComponents"
         app:cardBackgroundColor="@color/bg0"
         app:cardCornerRadius="10dp"
         app:layout_constraintBottom_toTopOf="@id/tv_productName"

--- a/feature/detail/src/main/java/com/peonlee/feature/detail/ProductCommentsActivity.kt
+++ b/feature/detail/src/main/java/com/peonlee/feature/detail/ProductCommentsActivity.kt
@@ -48,7 +48,6 @@ class ProductCommentsActivity : BaseActivity<ActivityProductCommentsBinding>() {
             finish()
         }
         rvProductComments.adapter = adapter
-
     }
 
     override fun bindViews() {

--- a/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
+++ b/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
@@ -3,15 +3,29 @@ package com.peonlee.explore
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import com.peonlee.core.ui.base.BaseActivity
+import com.peonlee.core.ui.extensions.hideKeyboard
+import com.peonlee.core.ui.extensions.trim
 import com.peonlee.explore.databinding.ActivityExploreActivityBinding
+import com.peonlee.product.ProductFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class ExploreActivity : BaseActivity<ActivityExploreActivityBinding>() {
     override fun bindingFactory(): ActivityExploreActivityBinding = ActivityExploreActivityBinding.inflate(layoutInflater)
 
     override fun initViews() = with(binding) {
-        etExplore.addTextChangedListener { input -> ivTextCleaer.isVisible = input?.isNotEmpty() ?: false }
+        etExploreBar.addTextChangedListener { input -> ivTextCleaer.isVisible = input?.isNotEmpty() ?: false }
         tvExploreCancel.setOnClickListener { finish() }
-        ivTextCleaer.setOnClickListener { etExplore.setText("") }
-        ivSearch.setOnClickListener { }
+        ivTextCleaer.setOnClickListener { etExploreBar.setText("") }
+        ivSearch.setOnClickListener {
+            binding.etExploreBar.hideKeyboard()
+            attachProduct()
+        }
+    }
+
+    private fun attachProduct() {
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.layout_search_product, ProductFragment(binding.etExploreBar.trim()))
+            .commit()
     }
 }

--- a/feature/explore/src/main/res/layout/activity_explore_activity.xml
+++ b/feature/explore/src/main/res/layout/activity_explore_activity.xml
@@ -7,7 +7,7 @@
     tools:context=".ExploreActivity">
 
     <EditText
-        android:id="@+id/et_explore"
+       android:id="@+id/et_explore_bar"
         style="@style/Text.Subtitle02"
         android:layout_width="0dp"
         android:layout_height="@dimen/explore_bar_height"
@@ -34,9 +34,9 @@
         android:padding="@dimen/space_medium"
         android:text="@string/explore_cancel"
         android:textColor="@color/bg40"
-        app:layout_constraintBottom_toBottomOf="@+id/et_explore"
+        app:layout_constraintBottom_toBottomOf="@+id/et_explore_bar"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/et_explore"></TextView>
+        app:layout_constraintTop_toTopOf="@+id/et_explore_bar"></TextView>
 
     <ImageView
         android:id="@+id/iv_search"
@@ -45,9 +45,9 @@
         android:layout_marginStart="@dimen/space_s_large"
         android:background="@drawable/ic_search"
         android:backgroundTint="@color/bg40"
-        app:layout_constraintBottom_toBottomOf="@+id/et_explore"
-        app:layout_constraintStart_toStartOf="@+id/et_explore"
-        app:layout_constraintTop_toTopOf="@+id/et_explore"></ImageView>
+        app:layout_constraintBottom_toBottomOf="@+id/et_explore_bar"
+        app:layout_constraintStart_toStartOf="@+id/et_explore_bar"
+        app:layout_constraintTop_toTopOf="@+id/et_explore_bar"></ImageView>
 
     <ImageView
         android:id="@+id/iv_text_cleaer"
@@ -57,16 +57,17 @@
         android:padding="@dimen/space_x_small"
         android:src="@drawable/ic_close_search"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@+id/et_explore"
-        app:layout_constraintEnd_toEndOf="@+id/et_explore"
-        app:layout_constraintTop_toTopOf="@+id/et_explore"></ImageView>
+        app:layout_constraintBottom_toBottomOf="@+id/et_explore_bar"
+        app:layout_constraintEnd_toEndOf="@+id/et_explore_bar"
+        app:layout_constraintTop_toTopOf="@+id/et_explore_bar"></ImageView>
 
     <FrameLayout
+        android:id="@+id/layout_search_product"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="@dimen/space_s_large"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/tv_explore_cancel"
-        app:layout_constraintStart_toStartOf="@+id/et_explore"
-        app:layout_constraintTop_toBottomOf="@+id/et_explore"></FrameLayout>
+        app:layout_constraintStart_toStartOf="@+id/et_explore_bar"
+        app:layout_constraintTop_toBottomOf="@+id/et_explore_bar"></FrameLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/product/src/main/java/com/peonlee/product/ProductFragment.kt
+++ b/feature/product/src/main/java/com/peonlee/product/ProductFragment.kt
@@ -32,7 +32,9 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ProductFragment : BaseFragment<FragmentProductBinding>() {
+class ProductFragment(
+    private val keyword: String? = null
+) : BaseFragment<FragmentProductBinding>() {
     @Inject
     lateinit var navigator: Navigator
 
@@ -62,6 +64,7 @@ class ProductFragment : BaseFragment<FragmentProductBinding>() {
     }
 
     override fun initViews() = with(binding) {
+        exploreViewModel.setKeyword(keyword)
         // 상단 상품 정렬 tab 설정
         com.peonlee.model.type.SortType.values().forEach {
             tabProductSort.addTab(

--- a/feature/product/src/main/java/com/peonlee/product/ProductViewModel.kt
+++ b/feature/product/src/main/java/com/peonlee/product/ProductViewModel.kt
@@ -35,6 +35,8 @@ class ProductViewModel @Inject constructor(
 
     val products: Flow<PagingData<ProductUiModel>>
 
+    private var keyword: String? = ""
+
     init {
         products = _productSearchCondition
             .flatMapLatest {
@@ -49,6 +51,7 @@ class ProductViewModel @Inject constructor(
         return try {
             productRepository.getProductsPaging(
                 ProductSearchRequest(
+                    keyword = keyword,
                     maxPrice = productSearch.price?.maxPrice,
                     minPrice = productSearch.price?.minPrice,
                     orderBy = productSearch.sortedBy.sortName,
@@ -94,5 +97,9 @@ class ProductViewModel @Inject constructor(
             keyword = _productSearchCondition.value.keyword,
             sortedBy = _productSearchCondition.value.sortedBy
         )
+    }
+
+    fun setKeyword(keyword: String?) {
+        this.keyword = keyword
     }
 }


### PR DESCRIPTION
## 참고사항 
- 검색화면에 재사용되는 상품 목록의 Fragment를 연동합니다.
- EditText 확장함수 hideKeyboard, trim 추가했습니다~~

![image](https://github.com/YAPP-Github/22nd-Android-Team-1-Android/assets/70135188/f2b3f69a-74a6-42f1-bda3-60f171e22d1f)


## 내용
1. 검색화면에 재사용되는 상품 목록의 Fragment를 연동
2. EditText 확장함수 hideKeyboard, trim 구현
3. Activity -> Fragment 데이터 전송 로직 구현


### Done!
 - [x] ProductFragment 부착
 - [x] Activity -> Fragment 데이터 전송 로직 구현

### 관련 Issue
#60