### PR TITLE
[FIX] 사용자 닉네임 한줄만 입력 가능하도록 처리 #107 Open 2 tasks

### DIFF
--- a/feature/user/src/main/res/layout/activity_modify_user_nickname.xml
+++ b/feature/user/src/main/res/layout/activity_modify_user_nickname.xml
@@ -32,7 +32,7 @@
         android:layout_marginTop="36dp"
         android:background="@null"
         android:gravity="center"
-        android:maxLines="1"
+        android:singleLine="true"
         android:textAlignment="center"
         android:textColor="@color/bg100"
         app:layout_constraintEnd_toEndOf="@id/btnCancel"


### PR DESCRIPTION
### 📌 내용
현재 사용자 닉네임을 2줄 이상으로 입력할 수 있게 되어있어, 이를 1줄만 입력 가능하도록 수정

### 🛠️ Done
 - [x] 닉네임 변경 화면
 - [x] 마이 페이지

### 🔖 작업 내용
- 닉네임을 작성하는 EditText에 singleLine을 true로 설정

### 🏠 관련 Issue
Closed #107 