### PR TITLE
[BUG] #117 : 탐색 화면의 검색 조건이 초기화되는 이슈 수정

### DIFF
--- a/core/ui/src/main/java/com/peonlee/core/ui/base/PageActivity.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/base/PageActivity.kt
@@ -1,0 +1,8 @@
+package com.peonlee.core.ui.base
+
+/**
+ * page 전환을 할 수 있는 Activity interface
+ */
+interface PageActivity {
+    fun moveToEvaluatePage()
+}

--- a/core/ui/src/main/java/com/peonlee/core/ui/viewmodel/ProductViewModel.kt
+++ b/core/ui/src/main/java/com/peonlee/core/ui/viewmodel/ProductViewModel.kt
@@ -1,6 +1,7 @@
-package com.peonlee.product
+package com.peonlee.core.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
@@ -65,13 +66,37 @@ class ProductViewModel @Inject constructor(
     }
 
     // 정렬 타입 변경
-    fun setProductSortType(sortType: SortType) {
-        _productSearchCondition.value = _productSearchCondition.value.copy(sortedBy = sortType)
+    fun setProductSortType(sortType: SortType, isReset: Boolean = false) {
+        _productSearchCondition.value = if (isReset) _productSearchCondition.value.copy(
+            keyword = "",
+            sortedBy = sortType,
+            price = null,
+            stores = null,
+            events = null,
+            categories = null
+        ) else _productSearchCondition.value.copy(sortedBy = sortType)
     }
 
     // 가격 필터 선택
     fun setPriceFilter(priceFilter: PriceFilter?) {
         _productSearchCondition.value = _productSearchCondition.value.copy(price = priceFilter)
+    }
+
+    // 편의점 변경
+    fun setStoreType(storeType: StoreType, isReset: Boolean = false) {
+        _productSearchCondition.value = if (isReset) _productSearchCondition.value.copy(
+            keyword = "",
+            sortedBy = SortType.RECENT,
+            price = null,
+            stores = listOf(storeType),
+            events = null,
+            categories = null
+        ) else _productSearchCondition.value.copy(stores = listOf(storeType))
+    }
+
+    // 검색 키워드 변경
+    fun setKeyword(keyword: String) {
+        _productSearchCondition.value = _productSearchCondition.value.copy(keyword = keyword)
     }
 
     // 이벤트 선택
@@ -99,5 +124,16 @@ class ProductViewModel @Inject constructor(
 
     fun setProductSearchCondition(newProductSearchCondition: ProductSearchConditionUiModel) {
         _productSearchCondition.value = newProductSearchCondition
+    }
+
+    class ProductViewModelFactory(
+        private val repository: ProductRepository
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(ProductViewModel::class.java)) {
+                return ProductViewModel(repository) as T
+            }
+            throw IllegalArgumentException("unKnown ViewModel class")
+        }
     }
 }

--- a/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
+++ b/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
@@ -10,19 +10,22 @@ import com.peonlee.core.ui.base.BaseActivity
 import com.peonlee.core.ui.extensions.hideKeyboard
 import com.peonlee.core.ui.extensions.trim
 import com.peonlee.core.ui.viewmodel.ProductViewModel
+import com.peonlee.data.product.ProductRepository
 import com.peonlee.explore.databinding.ActivityExploreActivityBinding
 import com.peonlee.product.ProductFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ExploreActivity : BaseActivity<ActivityExploreActivityBinding>() {
-    private val productViewModel: ProductViewModel by viewModels()
+    @Inject
+    lateinit var productRepository: ProductRepository
+    private val productViewModel: ProductViewModel by viewModels { ProductViewModel.ProductViewModelFactory(productRepository) }
 
-    //    private val exploreViewModel: ProductSearchableViewModel by viewModels { ExploreViewModel.ExploreViewModelFactory() }
     override fun bindingFactory(): ActivityExploreActivityBinding = ActivityExploreActivityBinding.inflate(layoutInflater)
 
     override fun initViews() {
-//        println(exploreViewModel)
+        productViewModel
         attachProductFragment()
     }
 

--- a/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
+++ b/feature/explore/src/main/java/com/peonlee/explore/ExploreActivity.kt
@@ -7,20 +7,22 @@ import androidx.activity.viewModels
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import com.peonlee.core.ui.base.BaseActivity
-import com.peonlee.core.ui.base.ProductSearchableViewModel
 import com.peonlee.core.ui.extensions.hideKeyboard
 import com.peonlee.core.ui.extensions.trim
+import com.peonlee.core.ui.viewmodel.ProductViewModel
 import com.peonlee.explore.databinding.ActivityExploreActivityBinding
 import com.peonlee.product.ProductFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ExploreActivity : BaseActivity<ActivityExploreActivityBinding>() {
-    private val exploreViewModel: ProductSearchableViewModel by viewModels { ExploreViewModel.ExploreViewModelFactory() }
+    private val productViewModel: ProductViewModel by viewModels()
+
+    //    private val exploreViewModel: ProductSearchableViewModel by viewModels { ExploreViewModel.ExploreViewModelFactory() }
     override fun bindingFactory(): ActivityExploreActivityBinding = ActivityExploreActivityBinding.inflate(layoutInflater)
 
     override fun initViews() {
-        println(exploreViewModel)
+//        println(exploreViewModel)
         attachProductFragment()
     }
 
@@ -47,7 +49,7 @@ class ExploreActivity : BaseActivity<ActivityExploreActivityBinding>() {
     private fun searchResult() {
         binding.apply {
             layoutSearchProduct.isVisible = true
-            (exploreViewModel as? ExploreViewModel)?.setKeyword(etExploreBar.trim())
+            productViewModel.setKeyword(etExploreBar.trim())
             etExploreBar.clearFocus()
             etExploreBar.hideKeyboard()
         }

--- a/feature/explore/src/main/java/com/peonlee/product/ProductFragment.kt
+++ b/feature/explore/src/main/java/com/peonlee/product/ProductFragment.kt
@@ -7,18 +7,15 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.tabs.TabLayout
 import com.peonlee.core.ui.Navigator
 import com.peonlee.core.ui.adapter.decoration.ContentPaddingDecoration
 import com.peonlee.core.ui.base.BaseBottomSheetFragment
 import com.peonlee.core.ui.base.BaseFragment
-import com.peonlee.core.ui.base.ProductSearchableViewModel
+import com.peonlee.core.ui.viewmodel.ProductViewModel
 import com.peonlee.model.product.ProductSearchConditionUiModel
 import com.peonlee.model.type.SortType
 import com.peonlee.model.type.toRangeString
@@ -34,7 +31,6 @@ import com.peonlee.product.ui.PriceFilterBottomSheetFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -42,8 +38,7 @@ class ProductFragment : BaseFragment<FragmentProductBinding>() {
     @Inject
     lateinit var navigator: Navigator
 
-    private val exploreViewModel: ProductSearchableViewModel by activityViewModels()
-    private val productViewModel: ProductViewModel by viewModels()
+    private val productViewModel: ProductViewModel by activityViewModels()
 
     private var currentBottomSheet: BaseBottomSheetFragment? = null
     private val priceFilter by lazy {
@@ -69,7 +64,7 @@ class ProductFragment : BaseFragment<FragmentProductBinding>() {
     }
 
     override fun initViews() = with(binding) {
-        observeKeyword()
+//        observeKeyword()
 
         SortType.values().forEach {
             tabProductSort.addTab(
@@ -177,16 +172,15 @@ class ProductFragment : BaseFragment<FragmentProductBinding>() {
             ?.show(childFragmentManager, "Filter")
     }
 
-    private fun observeKeyword() {
-        println(exploreViewModel)
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                exploreViewModel.productSearchCondition.collect {
-                    productViewModel.setProductSearchCondition(it)
-                }
-            }
-        }
-    }
+//    private fun observeKeyword() {
+//        viewLifecycleOwner.lifecycleScope.launch {
+//            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+//                exploreViewModel.productSearchCondition.collect {
+//                    productViewModel.setProductSearchCondition(it)
+//                }
+//            }
+//        }
+//    }
 
     companion object {
         fun getInstance(): ProductFragment = ProductFragment()

--- a/feature/home/src/main/java/com/peonlee/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/peonlee/home/HomeFragment.kt
@@ -8,7 +8,8 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.peonlee.core.ui.Navigator
 import com.peonlee.core.ui.base.BaseFragment
-import com.peonlee.core.ui.base.ProductSearchableViewModel
+import com.peonlee.core.ui.base.PageActivity
+import com.peonlee.core.ui.viewmodel.ProductViewModel
 import com.peonlee.home.adapter.HomeAdapter
 import com.peonlee.home.databinding.FragmentHomeBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,15 +21,20 @@ import javax.inject.Inject
 class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     @Inject
     lateinit var navigator: Navigator
-
+    private val productSearchableViewModel: ProductViewModel by activityViewModels()
     private val homeViewModel: HomeViewModel by viewModels()
-    private val productSearchableViewModel: ProductSearchableViewModel by activityViewModels()
 
     private val homeAdapter by lazy {
         HomeAdapter(
             navigator = navigator,
-            moveToConditionExplore = productSearchableViewModel::changeSortType,
-            moveToStoreExplore = productSearchableViewModel::changeStoreType
+            moveToConditionExplore = {
+                (requireActivity() as? PageActivity)?.moveToEvaluatePage()
+                productSearchableViewModel.setProductSortType(it, true)
+            },
+            moveToStoreExplore = {
+                (requireActivity() as? PageActivity)?.moveToEvaluatePage()
+                productSearchableViewModel.setStoreType(it, true)
+            }
         )
     }
 
@@ -38,6 +44,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
 
     override fun initViews() {
         binding.rvHome.adapter = homeAdapter
+//        productSearchableViewModel
         binding.btnSearch.setOnClickListener {
             navigator.navigateToSearch(requireContext())
         }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(project(":feature:evaluate"))
     implementation(project(":core:model"))
 
+    implementation(project(":core:data"))
+
     implementation(libs.google.material)
     implementation(libs.bundles.fragment)
 }

--- a/feature/main/src/main/java/com/peonlee/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/peonlee/main/MainActivity.kt
@@ -6,17 +6,24 @@ import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.peonlee.core.ui.base.BaseActivity
-import com.peonlee.core.ui.base.ProductSearchableViewModel
+import com.peonlee.core.ui.base.PageActivity
+import com.peonlee.core.ui.viewmodel.ProductViewModel
+import com.peonlee.data.product.ProductRepository
 import com.peonlee.main.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @AndroidEntryPoint
-class MainActivity : BaseActivity<ActivityMainBinding>() {
-    private val mainViewModel: ProductSearchableViewModel by viewModels { MainViewModel.MainViewModelFactory() }
+class MainActivity : BaseActivity<ActivityMainBinding>(), PageActivity {
+    @Inject
+    lateinit var productRepository: ProductRepository
+    private val productViewModel: ProductViewModel by viewModels { ProductViewModel.ProductViewModelFactory(productRepository) }
+    private val mainViewModel: MainViewModel by viewModels { MainViewModel.MainViewModelFactory() }
 
     override fun initViews() {
+        productViewModel
         binding.bottomNav.setOnItemSelectedListener {
             (mainViewModel as? MainViewModel)?.changeSelectedNav(it.itemId)
             true
@@ -50,6 +57,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         val count = supportFragmentManager.backStackEntryCount
         for (i in 0 until count) supportFragmentManager.popBackStack()
         super.onBackPressed()
+    }
+
+    override fun moveToEvaluatePage() {
+        mainViewModel.changeSelectedNav(R.id.navExplore)
     }
 
     companion object {

--- a/feature/main/src/main/java/com/peonlee/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/peonlee/main/MainViewModel.kt
@@ -2,10 +2,6 @@ package com.peonlee.main
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.peonlee.core.ui.base.ProductSearchableViewModel
-import com.peonlee.model.product.ProductSearchConditionUiModel
-import com.peonlee.model.type.SortType
-import com.peonlee.model.type.StoreType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,7 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor() : ProductSearchableViewModel() {
+class MainViewModel @Inject constructor() : ViewModel() {
     private val _selectedNav = MutableStateFlow<Int>(R.id.navHome)
     val selectedNav: StateFlow<Int> = _selectedNav.asStateFlow()
 
@@ -24,21 +20,21 @@ class MainViewModel @Inject constructor() : ProductSearchableViewModel() {
         _selectedNav.value = navId
     }
 
-    /**
-     * 정렬 키워드 변경
-     */
-    override fun changeSortType(sortType: SortType) {
-        _productSearchCondition.value = ProductSearchConditionUiModel(sortedBy = sortType)
-        _selectedNav.value = R.id.navExplore
-    }
-
-    /**
-     * 편의점의 행사 상품 변경
-     */
-    override fun changeStoreType(storeType: StoreType) {
-        _productSearchCondition.value = ProductSearchConditionUiModel(stores = listOf(storeType))
-        _selectedNav.value = R.id.navExplore
-    }
+//    /**
+//     * 정렬 키워드 변경
+//     */
+//    override fun changeSortType(sortType: SortType) {
+//        _productSearchCondition.value = ProductSearchConditionUiModel(sortedBy = sortType)
+//        _selectedNav.value = R.id.navExplore
+//    }
+//
+//    /**
+//     * 편의점의 행사 상품 변경
+//     */
+//    override fun changeStoreType(storeType: StoreType) {
+//        _productSearchCondition.value = ProductSearchConditionUiModel(stores = listOf(storeType))
+//        _selectedNav.value = R.id.navExplore
+//    }
 
     class MainViewModelFactory : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {


### PR DESCRIPTION
### 📌 내용
```
기존에는 메인 탭에서 탐색 화면으로 검색 조건을 emit하는 flow가 있어,
앱이 background로 갔다가 다시 돌아왔을 때 기존 검색 조건을 유지하지 못하는 이슈가 있었습니다.
```

### 🛠 해결 방법
[기존]
- 검색 조건을 ProductFragment에서 생성한 ProductViewModel에서 관리

[수정]
- ProductViewModel을 ProductFragment가 속한 Activity(`MainActivity, ExploreActivity`)에서 주입받고 ProductFragment에서는 이러한 ViewModel을 가져다 사용하도록 수정
- 검색 조건을 한 곳에서 관리하기 때문에 중복 문제 및 Background에서 돌아왔을 때 초기화 문제 해결
